### PR TITLE
enable DNS hostnames for VPC

### DIFF
--- a/modules/infrastructure/main.tf
+++ b/modules/infrastructure/main.tf
@@ -28,6 +28,7 @@ module "vpc" {
 
   enable_nat_gateway = true
   single_nat_gateway = true
+  enable_dns_hostnames = true
 
   public_subnet_tags = {
     KubernetesCluster        = "${var.cluster_name}-cluster"


### PR DESCRIPTION
Without that we can't use CNAME to point to any of the nodes sitting in the same VPC.

Not really we need this in our production setups but for dev envs we might want to run some other service (kafka, etc) alongside the Kubernetes in the same VPC and we need DNS resolution for these.