### PR TITLE
Downgraded Kubernetes version for Linux.

### DIFF
--- a/example/providers.tf
+++ b/example/providers.tf
@@ -8,7 +8,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "~> 1.10"
+  version                = "1.10.0"
 }
 
 provider "helm" {


### PR DESCRIPTION
Something is broken on 1.11 For now the best solution in the case of this module is just to pin to 1.10.0: