### PR TITLE
Fix error: repo jetstack not found

### DIFF
--- a/modules/system/main.tf
+++ b/modules/system/main.tf
@@ -323,6 +323,12 @@ resource "helm_release" "issuers" {
   }
 }
 
+# Install jetstack Helm repository
+data "helm_repository" "jetstack" {
+  name = "jetstack"
+  url  = "https://charts.jetstack.io"
+}
+
 # Deploy cert-manager (ingress certificate manager)
 resource "helm_release" "cert-manager" {
   depends_on = [
@@ -334,7 +340,7 @@ resource "helm_release" "cert-manager" {
   ]
 
   name          = "cert-manager"
-  repository    = "https://charts.jetstack.io"
+  repository    = data.helm_repository.jetstack.metadata[0].name
   chart         = "cert-manager"
   version       = "v0.13.1"
   namespace     = kubernetes_namespace.cert-manager.metadata[0].name


### PR DESCRIPTION
This PR fixes `repo jetstack not found` error, when installing a helm release for cert-manager:
https://github.com/terraform-providers/terraform-provider-helm/issues/354

