### PR TITLE
fix kubelet_extra_args register-with-taints arguments

### DIFF
--- a/modules/kubernetes/local.tf
+++ b/modules/kubernetes/local.tf
@@ -48,7 +48,7 @@ locals {
       on_demand_percentage_above_base_capacity = var.on_demand_cpu_percentage_above_base_capacity
       autoscaling_enabled                      = false
       subnets                                  = var.subnets
-      kubelet_extra_args                       = "--node-labels=node.kubernetes.io/lifecycle=cpu,node-type=cpu --register-with-taints=node-type=cpu:NoSchedule"
+      kubelet_extra_args                       = join(" ", ["--node-labels=node.kubernetes.io/lifecycle=normal,node-type=cpu", "--register-with-taints=node-type=cpu:NoSchedule"])
       suspended_processes                      = ["AZRebalance"]
       tags = [
         {
@@ -89,7 +89,7 @@ locals {
       ami_id                                   = data.aws_ami.eks_gpu_worker.id
       autoscaling_enabled                      = false
       subnets                                  = var.subnets
-      kubelet_extra_args                       = "--node-labels=node.kubernetes.io/lifecycle=gpu,node-type=gpu,nvidia.com/gpu=gpu --register-with-taints=node-type=gpu:NoSchedule,nvidia.com/gpu=gpu:NoSchedule"
+      kubelet_extra_args                       = join(" ", ["--node-labels=node.kubernetes.io/lifecycle=normal,node-type=gpu,nvidia.com/gpu=gpu", "--register-with-taints=node-type=gpu:NoSchedule,nvidia.com/gpu=gpu:NoSchedule"])
       suspended_processes                      = ["AZRebalance"]
       tags = [
         {


### PR DESCRIPTION
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/962#issuecomment-666184418

Arguments must be passed as an array. currently, only the first argument is read, and node taint does not work