### PR TITLE
Add Katib deployment for Kubeflow

### DIFF
--- a/modules/kubeflow/templates/kfctl.tmpl
+++ b/modules/kubeflow/templates/kfctl.tmpl
@@ -239,6 +239,21 @@ spec:
         name: manifests
         path: mpi-job/mpi-operator
     name: mpi-operator
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz


### PR DESCRIPTION
Fixes #94. The template for `kfctl.yaml` was missing a statement for deploying Katib. I'm not sure how to make this deployment optional.