### PR TITLE
Add HPA module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,17 @@
 
 ## What You Can Help With
 
-Currently, we accept contributions to the documentation of modules, specifically README.md files of each module. You can contribute in the following ways: 
-* Create a new Readme that is currently missing, add structure and write it in full or in part 
-* Add missing sections, paragraphs, and information to existing READMEs 
+Currently, we accept contributions to the documentation of modules, specifically README.md files of each module. You can contribute in the following ways:
+* Create a new Readme that is currently missing, add structure and write it in full or in part
+* Add missing sections, paragraphs, and information to existing READMEs
 * Correct typos and formatting issues
 * Add/propose graphics to illustrate documentation
 
 ## Getting Started
 
-Swiss Army Kube documentation welcomes improvements from all contributors, new and experienced. Anyone can contribute to the `github.com/provectus/swiss-army-kube` repository in the following formats: 
+Swiss Army Kube documentation welcomes improvements from all contributors, new and experienced. Anyone can contribute to the `github.com/provectus/swiss-army-kube` repository in the following formats:
 1. Open an issue about the documentation
-2. Propose a change with a pull request (PR) 
+2. Propose a change with a pull request (PR)
 3. Propose minor text/formatting edits right on GitHub without cloning
 
 All you need is being comfortable with Git and GitHub.
@@ -24,11 +24,11 @@ Find an [issue](https://github.com/provectus/swiss-army-kube/issues) to work on 
 ## Contributing Pull Requests (PRs)
 
 Please check our guide on how to contribute to Swiss Army Kube with PRs:
-* [Contributing Pull Requests](https://github.com/provectus/swiss-army-kube/blob/feature/new_docs/docs/CONTRIBUTE_PR.md)
+* [Contributing Pull Requests](https://github.com/provectus/swiss-army-kube/blob/master/docs/CONTRIBUTE_PR.md)
 
 ## Select a Module to Contribute
 
-The list of all Swiss Army Kube modules below includes information on the current state of documentation for each Module. 
+The list of all Swiss Army Kube modules below includes information on the current state of documentation for each Module.
 Please select a module to contribute:
 *  [airflow](https://github.com/provectus/swiss-army-kube/tree/master/modules/airflow)                          (has short annotation)
 *  [cicd](https://github.com/provectus/swiss-army-kube/tree/master/modules/cicd)                                (no Readme)
@@ -62,6 +62,6 @@ Approximate structure of a README.md document:
 * Configuration
 * Overrides
 
-In some cases, modules won't need some of these sections or require additional ones. Change it according to a particular module.    
+In some cases, modules won't need some of these sections or require additional ones. Change it according to a particular module.
 
 <a href="#top">Back to top</a>

--- a/docs/CONTRIBUTE_PR.md
+++ b/docs/CONTRIBUTE_PR.md
@@ -1,36 +1,37 @@
-# Contributing Pull Requests  
+# Contributing Pull Requests
 
 This guide is written for contributing to documentation. It doesn't contain any instructions on installing software prerequisites. If your intended contribution requires any software installations, please refer to their respective official documentation.
 
 **Prerequisites**
 * Git installed on your local machine
-* GitHub account 
+* GitHub account
 
 **Contents**
 
-2. [PR Contribution Workflow](#workflow)   
-3. [Basic Workflow Example](#example)  
-4. [PR Acceptance policy](#accept)  
+2. [PR Contribution Workflow](#workflow)
+3. [Basic Workflow Example](#example)
+4. [PR Acceptance policy](#accept)
 
 <a name="workflow"></a>
 ## PR Contribution Workflow
 
-1. [Fork and clone this repository (`git clone`)](#clonerepo)  
-2. [Create a feature branch against master (`git checkout -b featurename`)](#checkout)   
-3. [Make changes in the feature branch](#editdoc)  
-4. [Use Linter to ensure correct syntax and formatting (`terraform fmt`, `pre-commit run -a`)](#lintit)  
-5. [Commit your changes (`git commit -am "Add a feature"`)](#commit)   
-6. [Push your changes to GitHub (`git push origin feature`)](#push)    
-7. [Open a Pull Request and wait for your PR to get reviewed](#openPR)   
-8. [Edit your PR to address feedback (if any)](#modifyPR)   
-9. [See your PR getting merged](#merged)  
+1. [Fork and clone this repository (`git clone`)](#clonerepo)
+2. [Create a feature branch against master (`git checkout -b featurename`)](#checkout)
+3. [Make changes in the feature branch](#editdoc)
+4. [Update the documentation](#docs)
+5. [Use Linter to ensure correct syntax and formatting (`terraform fmt`, `pre-commit run -a`)](#lintit)
+6. [Commit your changes (`git commit -am "Add a feature"`)](#commit)
+7. [Push your changes to GitHub (`git push origin feature`)](#push)
+8. [Open a Pull Request and wait for your PR to get reviewed](#openPR)
+9. [Edit your PR to address feedback (if any)](#modifyPR)
+10. [See your PR getting merged](#merged)
 
 <a name="clonerepo"></a>
 ### 1. Fork and Clone this Repository
 
-In order to contribute, you need to make your own copy of the repository you're going to contribute to. You do this by forking the repository to your GitHub account and then cloning the fork to your local machine. 
+In order to contribute, you need to make your own copy of the repository you're going to contribute to. You do this by forking the repository to your GitHub account and then cloning the fork to your local machine.
 
-1. Fork this GitHub repository: on GitHub, navigate to the [main page of the repository](https://github.com/provectus/swiss-army-kube) and click the Fork button in the upper-right area of the screen. This will create a fork (a copy of this repository in your GitHub account). 
+1. Fork this GitHub repository: on GitHub, navigate to the [main page of the repository](https://github.com/provectus/swiss-army-kube) and click the Fork button in the upper-right area of the screen. This will create a fork (a copy of this repository in your GitHub account).
 2. Clone the fork and switch to the project directory by running in your terminal:
 ```
 git clone https://github.com/provectus/swiss-army-kube.git
@@ -38,14 +39,14 @@ cd swiss-army-kube
 ```
 <a name="checkout"></a>
 ### 2. Create a New Branch
-It is important to make all your changes in a separate branch created off the master branch. 
-Before any modifications to the repository that you've just cloned, create a new branch off of the master branch. 
+It is important to make all your changes in a separate branch created off the master branch.
+Before any modifications to the repository that you've just cloned, create a new branch off of the master branch.
 
 Create a new branch off of the current one and switch to it:
 ```
 git checkout -b <your-branch-name>
 ```
-To switch between branches, use the same command without the `-b` flag. For example, to switch back to the master branch: 
+To switch between branches, use the same command without the `-b` flag. For example, to switch back to the master branch:
 ```
 git checkout master
 ```
@@ -53,9 +54,9 @@ This way you can switch between multiple branches when you work on multiple feat
 
 #### Branch Naming Conventions
 
-Give your branch a descriptive name so that others working on the project understand what you are working on. The branch name should include the name of the module that you're contributing to. 
+Give your branch a descriptive name so that others working on the project understand what you are working on. The branch name should include the name of the module that you're contributing to.
 
-Name your branch according to the following template, replacing `nginx` with the name of the module you're contributing to: 
+Name your branch according to the following template, replacing `nginx` with the name of the module you're contributing to:
 ```
 feature/docs_nginx
 ```
@@ -63,18 +64,28 @@ feature/docs_nginx
 <a name="editdoc"></a>
 ### 3. Make Changes
 
-Make changes you want to propose. Make sure you do this in a dedicated branch based on the master branch. 
+Make changes you want to propose. Make sure you do this in a dedicated branch based on the master branch.
+
+<a name="docs"></a>
+### 4. Update the documentation
+
+Make sure to update the documentation. Each module should be properly documented:
+- the purpose of the module is stated;
+- pre-requisites and requirements for the module are given;
+- there is a list of input and output variables used inside the module.
+
+You can use [`terraform-docs`](https://github.com/terraform-docs/terraform-docs/) to automatically generate the documentation for the module
 
 <a name="lintit"></a>
-### 4. Use Linter for Correct Syntax & Formatting
+### 5. Use Linter for Correct Syntax & Formatting
 
 When applicable, use linters for Terraform to ensure proper formatting before committing and pushing your changes. Check your repository with one of them:
-* **[Terraform formatting](https://www.terraform.io/docs/commands/fmt.html)** - run `terraform fmt && tflint` 
-* **[pre-commit-terraform](https://github.com/antonbabenko/pre-commit-terraform)** - run `pre-commit run -a` after installing and configuring the tool. 
+* **[Terraform formatting](https://www.terraform.io/docs/commands/fmt.html)** - run `terraform fmt && tflint`
+* **[pre-commit-terraform](https://github.com/antonbabenko/pre-commit-terraform)** - run `pre-commit run -a` after installing and configuring the tool.
 
 <a name="commit"></a>
-### 5. Commit Changes
-Commit changes often to avoid accidental data loss. Make sure to provide your commits with descriptive comments.  
+### 6. Commit Changes
+Commit changes often to avoid accidental data loss. Make sure to provide your commits with descriptive comments.
 
 ```
 git add .
@@ -86,31 +97,31 @@ git commit -am "Add description"
 ```
 
 <a name="push"></a>
-### 6. Push Changes to GitHub
+### 7. Push Changes to GitHub
 
-Push your local changes to your fork on GitHub. 
+Push your local changes to your fork on GitHub.
 ```
 git push <repo-name> <branch-name>
 ```
-For example, if your remote repository is called origin and you want to push a branch named Mod-argo: 
+For example, if your remote repository is called origin and you want to push a branch named Mod-argo:
 ```
 git push origin Mod-argo
 ```
 
 <a name="openPR"></a>
-### 7. Open a Pull Request
+### 8. Open a Pull Request
 
-Navigate to your fork on GitHub. Press the "New pull request" button in the upper-left part of the page. Add a title and a comment. Once you press the "Create pull request" button, the maintainers of this repository will receive your PR. 
+Navigate to your fork on GitHub. Press the "New pull request" button in the upper-left part of the page. Add a title and a comment. Once you press the "Create pull request" button, the maintainers of this repository will receive your PR.
 
 <a name="modifyPR"></a>
-### 8. Address Feedback
+### 9. Address Feedback
 
-After you submit the PR, one or several of the Swiss Army Kube reviewers will provide you with actionable feedback. Edit your PR to address all of the comments. Reviewers do their best to provide feedback and approval in a timely fashion but note that response time may vary based on circumstances. 
+After you submit the PR, one or several of the Swiss Army Kube reviewers will provide you with actionable feedback. Edit your PR to address all of the comments. Reviewers do their best to provide feedback and approval in a timely fashion but note that response time may vary based on circumstances.
 
 <a name="merged"></a>
-### 9. Your PR Gets Merged
+### 10. Your PR Gets Merged
 
-Once your PR is approved by a reviewer, it gets accepted and merged with the main repository. Merged PRs will get included in the next Swiss Army Kube release.  
+Once your PR is approved by a reviewer, it gets accepted and merged with the main repository. Merged PRs will get included in the next Swiss Army Kube release.
 
 <a name="example"></a>
 ## Basic Workflow Example
@@ -128,36 +139,36 @@ git push origin Mod-argo
 
 What will make your PR more likely to get accepted:
 
-* Having your fixes on a dedicated branch 
+* Having your fixes on a dedicated branch
 * Proper branch naming
 * Descriptive commit messages
-* PR title describing what changed 
+* PR title describing what changed
 * PR comment describing why/where it changed in <80 chars
 * Texts checked for spelling and typos (you can use Grammarly)
-* Terraform code snippets checked with linters (when applicable)  
+* Terraform code snippets checked with linters (when applicable)
 
 ### PR Title and Comment Conventions
 
-A PR title should describe what has changed. A PR comment should describe why and what/where. If your changes relate to a particular issue, a PR comment should contain an issue number. Please keep PR comments below 80 characters for readability. 
+A PR title should describe what has changed. A PR comment should describe why and what/where. If your changes relate to a particular issue, a PR comment should contain an issue number. Please keep PR comments below 80 characters for readability.
 
 PR title example:
 ```
-Kubernetes: added 2 sections and notification. System: new structure, description, minor fixes. 
+Kubernetes: added 2 sections and notification. System: new structure, description, minor fixes.
 ```
 
-PR comment example:  
+PR comment example:
 
 ```
-Kubernetes: added sections: "Requirements", "How to update SAK module Kubeflow". 
-Added version table showing the compatibility of Kubernetes and Kubeflow versions.  
-Added notification about changes to what files will trigger Kubeflow terraform 
+Kubernetes: added sections: "Requirements", "How to update SAK module Kubeflow".
+Added version table showing the compatibility of Kubernetes and Kubeflow versions.
+Added notification about changes to what files will trigger Kubeflow terraform
 resources recreation.
 
-System: rearranged file structure according to best practice. Finished the module 
+System: rearranged file structure according to best practice. Finished the module
 description section. Added a warning about using GPUs and a container. Fixed typos
-and formatting throughout the whole file. 
+and formatting throughout the whole file.
 
 Issue #42
 ```
 
-Minor edits (typos, spelling, formatting, adding small text pieces) may get waved through. More substantial changes normally require more time, reviewers, and back-and-forths, and you might get asked for a PR resubmission or dividing changes into more that one PR. Usually, PRs are getting merged right after the approval.  
+Minor edits (typos, spelling, formatting, adding small text pieces) may get waved through. More substantial changes normally require more time, reviewers, and back-and-forths, and you might get asked for a PR resubmission or dividing changes into more that one PR. Usually, PRs are getting merged right after the approval.

--- a/modules/scaling/README.md
+++ b/modules/scaling/README.md
@@ -1,0 +1,35 @@
+Deploys Cluster Autoscaler (https://github.com/kubernetes/autoscaler) and Horizontal Pod Autoscaler (https://github.com/banzaicloud/hpa-operator) operator charts.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12, < 0.14 |
+| aws | >= 2.0, < 4.0 |
+| helm | >= 0.10, < 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 2.0, < 4.0 |
+| helm | >= 0.10, < 2.0 |
+| kubernetes | >= 1.11 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| cluster\_autoscaler\_chart\_version | Version of Cluster Autoscaler chart | `string` | `"7.2.2"` | no |
+| cluster\_autoscaler\_conf | A set of parameters to pass to Cluster Autoscaler Helm chart (see: https://github.com/kubernetes/autoscaler) | `map` | `{}` | no |
+| cluster\_autoscaler\_enabled | Whether to deploy Cluster Autoscaler chart | `bool` | `true` | no |
+| cluster\_name | The name of the cluster the charts will be deployed to | `string` | n/a | yes |
+| hpa\_chart\_version | Version of Horizontal Pod Autoscaler chart | `string` | `"0.2.4"` | no |
+| hpa\_conf | A set of parameters to pass to Horizontal Pod Autoscaler Helm chart (see: https://github.com/banzaicloud/hpa-operator) | `map` | `{}` | no |
+| hpa\_enabled | Whether to deploy Horizontal Pod Autoscaler chart | `bool` | `true` | no |
+| module\_depends\_on | A list of explicit dependencies for the module | `list` | `[]` | no |
+| namespace | A namespace where Helm charts will be deployed to | `string` | `"kube-system"` | no |
+
+## Outputs
+
+No output.

--- a/modules/scaling/cluster-autoscaler.tf
+++ b/modules/scaling/cluster-autoscaler.tf
@@ -1,0 +1,102 @@
+resource "helm_release" "cluster_autoscaler" {
+  depends_on = [
+    var.module_depends_on
+  ]
+  count      = var.cluster_autoscaler_enabled ? 1 : 0
+  name       = "aws-cluster-autoscaler"
+  repository = "https://kubernetes-charts.storage.googleapis.com/"
+  chart      = "cluster-autoscaler"
+  version    = var.cluster_autoscaler_chart_version
+  namespace  = data.kubernetes_namespace.this[0].metadata[0].name
+  timeout    = 1200
+  dynamic set {
+    for_each = merge(local.cluster_autoscaler_conf_defaults, var.cluster_autoscaler_conf)
+
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+}
+
+module "iam_assumable_role_admin" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "~> v2.6.0"
+  create_role                   = var.cluster_autoscaler_enabled
+  role_name                     = "${var.cluster_name}_cluster-autoscaler"
+  provider_url                  = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
+  role_policy_arns              = [aws_iam_policy.cluster_autoscaler[0].arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:aws-cluster-autoscaler"]
+}
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  depends_on = [
+    var.module_depends_on
+  ]
+  count       = var.cluster_autoscaler_enabled ? 1 : 0
+  name_prefix = "cluster-autoscaler"
+  description = "EKS cluster-autoscaler policy for cluster ${data.aws_eks_cluster.this.id}"
+  policy      = data.aws_iam_policy_document.cluster_autoscaler.json
+}
+
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  statement {
+    sid    = "clusterAutoscalerAll"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "clusterAutoscalerOwn"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${data.aws_eks_cluster.this.id}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
+      values   = ["true"]
+    }
+  }
+}
+
+locals {
+  cluster_autoscaler_conf_defaults = {
+    "cloudProvider"                                                 = "aws"
+    "image.repository"                                              = "us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler"
+    "image.tag"                                                     = "v1.16.6" # Make sure it matches the version of the cluster
+    "autoDiscovery.clusterName"                                     = var.cluster_name,
+    "autoDiscovery.enabled"                                         = true
+    "awsRegion"                                                     = data.aws_region.current.name,
+    "extraArgs.balance-similar-node-groups"                         = true,
+    "extraArgs.scale-down-enabled"                                  = true,
+    "rbac.create"                                                   = true,
+    "rbac.serviceAccountAnnotations.eks\\.amazonaws\\.com/role-arn" = module.iam_assumable_role_admin.this_iam_role_arn
+    "rbac.pspEnabled"                                               = true,
+    "resources.limits.cpu"                                          = "100m",
+    "resources.limits.memory"                                       = "300Mi",
+    "resources.requests.cpu"                                        = "100m",
+    "resources.requests.memory"                                     = "300Mi",
+  }
+}

--- a/modules/scaling/hpa.tf
+++ b/modules/scaling/hpa.tf
@@ -1,0 +1,24 @@
+resource "helm_release" "hpa_operator" {
+  depends_on = [
+    var.module_depends_on
+  ]
+  count      = var.hpa_enabled ? 1 : 0
+  name       = "hpa-operator"
+  repository = "https://kubernetes-charts.banzaicloud.com"
+  chart      = "hpa-operator"
+  version    = var.hpa_chart_version
+  namespace  = data.kubernetes_namespace.this[0].metadata[0].name
+  timeout    = 1200
+  dynamic set {
+    for_each = merge(local.hpa_conf_defaults, var.hpa_conf)
+
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+}
+
+locals {
+  hpa_conf_defaults = {}
+}

--- a/modules/scaling/main.tf
+++ b/modules/scaling/main.tf
@@ -6,113 +6,19 @@ data "aws_eks_cluster" "this" {
   name = var.cluster_name
 }
 
+data "kubernetes_namespace" "this" {
+  count = var.hpa_enabled || var.cluster_autoscaler_enabled ? 1 : 0
+  metadata {
+    name = var.namespace == "kube-system" ? "kube-system" : kubernetes_namespace.this[0].metadata[0].name
+  }
+}
+
 resource "kubernetes_namespace" "this" {
   depends_on = [
     var.module_depends_on
   ]
-  count = var.namespace == "kube-system" ? 0 : 1
+  count = var.namespace != "kube-system" && (var.hpa_enabled || var.cluster_autoscaler_enabled) ? 1 : 0
   metadata {
     name = var.namespace
-  }
-}
-
-resource "helm_release" "cluster_autoscaler" {
-  depends_on = [
-    var.module_depends_on
-  ]
-  name       = "aws-cluster-autoscaler"
-  repository = "https://kubernetes-charts.storage.googleapis.com/"
-  chart      = "cluster-autoscaler"
-  version    = "7.2.2"
-  namespace  = var.namespace
-  timeout    = 1200
-  dynamic set {
-    for_each = merge(local.autoscaler_conf_defaults, var.autoscaler_conf)
-
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-}
-
-module "iam_assumable_role_admin" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> v2.6.0"
-  create_role                   = true
-  role_name                     = "${var.cluster_name}_cluster-autoscaler"
-  provider_url                  = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
-  role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:aws-cluster-autoscaler"]
-}
-
-resource "aws_iam_policy" "cluster_autoscaler" {
-  depends_on = [
-    var.module_depends_on
-  ]
-  name_prefix = "cluster-autoscaler"
-  description = "EKS cluster-autoscaler policy for cluster ${data.aws_eks_cluster.this.id}"
-  policy      = data.aws_iam_policy_document.cluster_autoscaler.json
-}
-
-data "aws_iam_policy_document" "cluster_autoscaler" {
-  statement {
-    sid    = "clusterAutoscalerAll"
-    effect = "Allow"
-
-    actions = [
-      "autoscaling:DescribeAutoScalingGroups",
-      "autoscaling:DescribeAutoScalingInstances",
-      "autoscaling:DescribeLaunchConfigurations",
-      "autoscaling:DescribeTags",
-      "ec2:DescribeLaunchTemplateVersions",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    sid    = "clusterAutoscalerOwn"
-    effect = "Allow"
-
-    actions = [
-      "autoscaling:SetDesiredCapacity",
-      "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
-    ]
-
-    resources = ["*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${data.aws_eks_cluster.this.id}"
-      values   = ["owned"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
-      values   = ["true"]
-    }
-  }
-}
-
-locals {
-  autoscaler_conf_defaults = {
-    "cloudProvider"                                                 = "aws"
-    "image.repository"                                              = "us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler"
-    "image.tag"                                                     = "v1.16.6"
-    "autoDiscovery.clusterName"                                     = var.cluster_name,
-    "autoDiscovery.enabled"                                         = true
-    "awsRegion"                                                     = data.aws_region.current.name,
-    "extraArgs.balance-similar-node-groups"                         = true,
-    "extraArgs.scale-down-enabled"                                  = true,
-    "rbac.create"                                                   = true,
-    "rbac.serviceAccountAnnotations.eks\\.amazonaws\\.com/role-arn" = module.iam_assumable_role_admin.this_iam_role_arn
-    "rbac.pspEnabled"                                               = true,
-    "resources.limits.cpu"                                          = "100m",
-    "resources.limits.memory"                                       = "300Mi",
-    "resources.requests.cpu"                                        = "100m",
-    "resources.requests.memory"                                     = "300Mi",
   }
 }

--- a/modules/scaling/variables.tf
+++ b/modules/scaling/variables.tf
@@ -1,16 +1,45 @@
 # For depends_on queqe
 variable "module_depends_on" {
-  default = []
+  default     = []
+  description = "A list of explicit dependencies for the module"
 }
 
-variable autoscaler_conf {
-  default = {}
+variable cluster_autoscaler_conf {
+  default     = {}
+  description = "A set of parameters to pass to Cluster Autoscaler Helm chart (see: https://github.com/kubernetes/autoscaler)"
+}
+
+variable hpa_conf {
+  default     = {}
+  description = "A set of parameters to pass to Horizontal Pod Autoscaler Helm chart (see: https://github.com/banzaicloud/hpa-operator)"
 }
 
 variable namespace {
-  default = "kube-system"
+  default     = "kube-system"
+  description = "A namespace where Helm charts will be deployed to"
 }
 
 variable cluster_name {
-  type = string
+  type        = string
+  description = "The name of the cluster the charts will be deployed to"
+}
+
+variable hpa_enabled {
+  default     = true
+  description = "Whether to deploy Horizontal Pod Autoscaler chart"
+}
+
+variable cluster_autoscaler_enabled {
+  default     = true
+  description = "Whether to deploy Cluster Autoscaler chart"
+}
+
+variable cluster_autoscaler_chart_version {
+  default     = "7.2.2"
+  description = "Version of Cluster Autoscaler chart"
+}
+
+variable hpa_chart_version {
+  default     = "0.2.4"
+  description = "Version of Horizontal Pod Autoscaler chart"
 }

--- a/modules/scaling/versions.tf
+++ b/modules/scaling/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.12, < 0.14"
+
+  required_providers {
+    aws        = ">= 2.0, < 4.0"
+    helm       = ">= 0.10, < 2.0"
+    kubernetes = ">= 1.11"
+  }
+}


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

Add Horizontal Pod Autoscaler (HPA) module. It will enable Deployments in the cluster to use annotations to control horizontal scaling: https://github.com/banzaicloud/hpa-operator#autoscale-by-annotations. Without it, one needed to manually create an object of Kind `HorizontalPodAutoscaler` for each Deployment.

- Remove redundant spaces in `docs/*`;
- Refactor `scaling` module to support both Cluster Autoscaler and HPA. Both are now optional and can be enabled separately;
- Add `README.md` for the module.
