### PR TITLE
Add AWS For Fluent Bit module

### DIFF
--- a/modules/logging/aws-for-fluent-bit/README.md
+++ b/modules/logging/aws-for-fluent-bit/README.md
@@ -1,0 +1,6 @@
+Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from 
+different sources, unify and send them to multiple destinations.
+
+[AWS For Fluent Bit Releases](https://github.com/aws/aws-for-fluent-bit/releases)
+[AWS For Fluent Bit Source](https://github.com/aws/aws-for-fluent-bit)
+[AWS For Fluent Bit Helm chart configuration](https://github.com/aws/eks-charts/blob/master/stable/aws-for-fluent-bit/README.md)

--- a/modules/logging/aws-for-fluent-bit/iam.tf
+++ b/modules/logging/aws-for-fluent-bit/iam.tf
@@ -1,0 +1,92 @@
+resource "aws_iam_policy" "cloudwatch_logs_policy" {
+  count = var.cloudwatch_enabled ? 1 : 0
+
+  name   = "${var.cluster_name}-aws-for-fluent-bit-cloudwatch-policy"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:PutRetentionPolicy",
+        "logs:CreateLogStream",
+        "logs:DescribeLogStreams",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:${var.aws_region}:${var.aws_account}:log-group:${var.cloudwatch_log_group_name}:log-stream:*"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_logs_role_policy_attachment" {
+  count = var.cloudwatch_enabled ? 1 : 0
+
+  role       = aws_iam_role.aws_for_fluent_bit_iam_role.name
+  policy_arn = aws_iam_policy.cloudwatch_logs_policy[count.index].arn
+}
+
+resource "aws_iam_policy" "firehose_policy" {
+  count = var.firehose_enabled ? 1 : 0
+  name  = "${var.cluster_name}-aws-for-fluent-bit-firehose-policy"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "firehose:PutRecord",
+        "firehose:PutRecordBatch"
+      ],
+      "Resource": [
+        "arn:aws:firehose:${var.aws_region}:${var.aws_account}:deliverystream/${var.firehose_delivery_stream}"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "firehose_role_policy_attachment" {
+  count = var.firehose_enabled ? 1 : 0
+
+  role       = aws_iam_role.aws_for_fluent_bit_iam_role.name
+  policy_arn = aws_iam_policy.firehose_policy[count.index].arn
+}
+
+resource "aws_iam_policy" "kinesis_policy" {
+  count = var.kinesis_enabled ? 1 : 0
+  name  = "${var.cluster_name}-aws-for-fluent-bit-kinesis-policy"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kinesis:PutRecord",
+        "kinesis:PutRecords"
+      ],
+      "Resource": [
+        "arn:aws:kinesis:${var.aws_region}:${var.aws_account}:stream/${var.kinesis_stream}"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "kinesis_role_policy_attachment" {
+  count = var.kinesis_enabled ? 1 : 0
+
+  role       = aws_iam_role.aws_for_fluent_bit_iam_role.name
+  policy_arn = aws_iam_policy.kinesis_policy[count.index].arn
+}

--- a/modules/logging/aws-for-fluent-bit/iam.tf
+++ b/modules/logging/aws-for-fluent-bit/iam.tf
@@ -1,3 +1,31 @@
+data "aws_iam_policy_document" "aws_for_fluent_bit_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(var.cluster_oidc_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:${local.namespace}:${var.service_account_name}"]
+    }
+
+    principals {
+      identifiers = [var.cluster_oidc_arn]
+      type        = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role" "aws_for_fluent_bit_iam_role" {
+  name               = "${var.cluster_name}-aws-for-fluent-bit"
+  assume_role_policy = data.aws_iam_policy_document.aws_for_fluent_bit_assume_role_policy.json
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project
+  }
+}
+
 resource "aws_iam_policy" "cloudwatch_logs_policy" {
   count = var.cloudwatch_enabled ? 1 : 0
 

--- a/modules/logging/aws-for-fluent-bit/main.tf
+++ b/modules/logging/aws-for-fluent-bit/main.tf
@@ -1,0 +1,82 @@
+# Create namespace logging
+resource "kubernetes_namespace" "logging" {
+  depends_on = [
+    var.module_depends_on
+  ]
+  metadata {
+    name = var.namespace_name
+  }
+}
+
+resource "helm_release" "aws-for-fluent-bit" {
+  depends_on = [
+    var.module_depends_on
+  ]
+
+  name = "aws-for-fluent-bit"
+  repository = "https://aws.github.io/eks-charts"
+  chart = "aws-for-fluent-bit"
+  version = "0.1.3"
+  namespace = var.namespace_name
+
+  values = [
+    templatefile("${path.module}/values/aws-for-fluent-bit.yaml", {
+      aws_region = var.aws_region
+      namespace = var.namespace_name
+
+      service_account_auto_create = var.service_account_auto_create
+      service_account_name = var.service_account_name
+      service_account_annotations = var.service_account_annotations
+
+      daemon_set_resources_limits_cpu = var.daemon_set_resources_limits_cpu
+      daemon_set_resources_limits_memory = var.daemon_set_resources_limits_memory
+      daemon_set_resources_requests_cpu = var.daemon_set_resources_requests_cpu
+      daemon_set_resources_requests_memory = var.daemon_set_resources_requests_memory
+
+      cloudwatch_enabled = var.cloudwatch_enabled
+      cloudwatch_match = var.cloudwatch_match
+      cloudwatch_log_group_name = var.cloudwatch_log_group_name
+      cloudwatch_log_stream_name = var.cloudwatch_log_stream_name
+      cloudwatch_log_stream_prefix = var.cloudwatch_log_stream_prefix
+      cloudwatch_log_key = var.cloudwatch_log_key
+      cloudwatch_log_format = var.cloudwatch_log_format
+      cloudwatch_role_arn = var.cloudwatch_role_arn
+      cloudwatch_auto_create_group = var.cloudwatch_auto_create_group
+      cloudwatch_endpoint = var.cloudwatch_endpoint
+      cloudwatch_credentials_endpoint = var.cloudwatch_credentials_endpoint
+
+      firehose_enabled = var.firehose_enabled
+      firehose_match = var.firehose_match
+      firehose_delivery_stream = var.firehose_delivery_stream
+      firehose_data_keys = var.firehose_data_keys
+      firehose_role_arn = var.firehose_role_arn
+      firehose_endpoint = var.firehose_endpoint
+      firehose_time_key = var.firehose_time_key
+      firehose_time_key_format = var.firehose_time_key_format
+
+      kinesis_enabled = var.kinesis_enabled
+      kinesis_match = var.kinesis_match
+      kinesis_stream = var.kinesis_stream
+      kinesis_partition_key = var.kinesis_partition_key
+      kinesis_append_new_line = var.kinesis_append_new_line
+      kinesis_data_keys = var.kinesis_data_keys
+      kinesis_role_arn = var.kinesis_role_arn
+      kinesis_endpoint = var.kinesis_endpoint
+      kinesis_sts_endpoint = var.kinesis_sts_endpoint
+      kinesis_time_key = var.kinesis_time_key
+      kinesis_time_key_format = var.kinesis_time_key_format
+      kinesis_compression = var.kinesis_compression
+      kinesis_aggregation = var.kinesis_aggregation
+      kinesis_experimental_concurrency = var.kinesis_experimental_concurrency
+      kinesis_experimental_concurrency_retries = var.kinesis_experimental_concurrency_retries
+
+      elastic_search = var.elastic_search_enabled
+      elastic_match = var.elastic_match
+      elastic_host = var.elastic_host
+      elastic_aws_auth = var.elastic_aws_auth
+      elastic_tls = var.elastic_tls
+      elastic_port = var.elastic_port
+      elastic_retry_limit = var.elastic_retry_limit
+    })
+  ]
+}

--- a/modules/logging/aws-for-fluent-bit/main.tf
+++ b/modules/logging/aws-for-fluent-bit/main.tf
@@ -9,34 +9,6 @@ resource "kubernetes_namespace" "this" {
   }
 }
 
-data "aws_iam_policy_document" "aws_for_fluent_bit_assume_role_policy" {
-  statement {
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    effect  = "Allow"
-
-    condition {
-      test     = "StringEquals"
-      variable = "${replace(var.cluster_oidc_url, "https://", "")}:sub"
-      values   = ["system:serviceaccount:${local.namespace}:${var.service_account_name}"]
-    }
-
-    principals {
-      identifiers = [var.cluster_oidc_arn]
-      type        = "Federated"
-    }
-  }
-}
-
-resource "aws_iam_role" "aws_for_fluent_bit_iam_role" {
-  name               = "${var.cluster_name}-aws-for-fluent-bit"
-  assume_role_policy = data.aws_iam_policy_document.aws_for_fluent_bit_assume_role_policy.json
-
-  tags = {
-    Environment = var.environment
-    Project     = var.project
-  }
-}
-
 // Configuration: https://github.com/aws/eks-charts/blob/master/stable/aws-for-fluent-bit/README.md
 resource "helm_release" "aws-for-fluent-bit" {
   depends_on = [

--- a/modules/logging/aws-for-fluent-bit/main.tf
+++ b/modules/logging/aws-for-fluent-bit/main.tf
@@ -13,70 +13,70 @@ resource "helm_release" "aws-for-fluent-bit" {
     var.module_depends_on
   ]
 
-  name = "aws-for-fluent-bit"
+  name       = "aws-for-fluent-bit"
   repository = "https://aws.github.io/eks-charts"
-  chart = "aws-for-fluent-bit"
-  version = "0.1.3"
-  namespace = var.namespace_name
+  chart      = "aws-for-fluent-bit"
+  version    = "0.1.3"
+  namespace  = var.namespace_name
 
   values = [
     templatefile("${path.module}/values/aws-for-fluent-bit.yaml", {
-      aws_region = var.aws_region
-      namespace = var.namespace_name
+      aws_region                               = var.aws_region
+      namespace                                = var.namespace_name
 
-      service_account_auto_create = var.service_account_auto_create
-      service_account_name = var.service_account_name
-      service_account_annotations = var.service_account_annotations
+      service_account_auto_create              = var.service_account_auto_create
+      service_account_name                     = var.service_account_name
+      service_account_annotations              = var.service_account_annotations
 
-      daemon_set_resources_limits_cpu = var.daemon_set_resources_limits_cpu
-      daemon_set_resources_limits_memory = var.daemon_set_resources_limits_memory
-      daemon_set_resources_requests_cpu = var.daemon_set_resources_requests_cpu
-      daemon_set_resources_requests_memory = var.daemon_set_resources_requests_memory
+      daemon_set_resources_limits_cpu          = var.daemon_set_resources_limits_cpu
+      daemon_set_resources_limits_memory       = var.daemon_set_resources_limits_memory
+      daemon_set_resources_requests_cpu        = var.daemon_set_resources_requests_cpu
+      daemon_set_resources_requests_memory     = var.daemon_set_resources_requests_memory
 
-      cloudwatch_enabled = var.cloudwatch_enabled
-      cloudwatch_match = var.cloudwatch_match
-      cloudwatch_log_group_name = var.cloudwatch_log_group_name
-      cloudwatch_log_stream_name = var.cloudwatch_log_stream_name
-      cloudwatch_log_stream_prefix = var.cloudwatch_log_stream_prefix
-      cloudwatch_log_key = var.cloudwatch_log_key
-      cloudwatch_log_format = var.cloudwatch_log_format
-      cloudwatch_role_arn = var.cloudwatch_role_arn
-      cloudwatch_auto_create_group = var.cloudwatch_auto_create_group
-      cloudwatch_endpoint = var.cloudwatch_endpoint
-      cloudwatch_credentials_endpoint = var.cloudwatch_credentials_endpoint
+      cloudwatch_enabled                       = var.cloudwatch_enabled
+      cloudwatch_match                         = var.cloudwatch_match
+      cloudwatch_log_group_name                = var.cloudwatch_log_group_name
+      cloudwatch_log_stream_name               = var.cloudwatch_log_stream_name
+      cloudwatch_log_stream_prefix             = var.cloudwatch_log_stream_prefix
+      cloudwatch_log_key                       = var.cloudwatch_log_key
+      cloudwatch_log_format                    = var.cloudwatch_log_format
+      cloudwatch_role_arn                      = var.cloudwatch_role_arn
+      cloudwatch_auto_create_group             = var.cloudwatch_auto_create_group
+      cloudwatch_endpoint                      = var.cloudwatch_endpoint
+      cloudwatch_credentials_endpoint          = var.cloudwatch_credentials_endpoint
 
-      firehose_enabled = var.firehose_enabled
-      firehose_match = var.firehose_match
-      firehose_delivery_stream = var.firehose_delivery_stream
-      firehose_data_keys = var.firehose_data_keys
-      firehose_role_arn = var.firehose_role_arn
-      firehose_endpoint = var.firehose_endpoint
-      firehose_time_key = var.firehose_time_key
-      firehose_time_key_format = var.firehose_time_key_format
+      firehose_enabled                         = var.firehose_enabled
+      firehose_match                           = var.firehose_match
+      firehose_delivery_stream                 = var.firehose_delivery_stream
+      firehose_data_keys                       = var.firehose_data_keys
+      firehose_role_arn                        = var.firehose_role_arn
+      firehose_endpoint                        = var.firehose_endpoint
+      firehose_time_key                        = var.firehose_time_key
+      firehose_time_key_format                 = var.firehose_time_key_format
 
-      kinesis_enabled = var.kinesis_enabled
-      kinesis_match = var.kinesis_match
-      kinesis_stream = var.kinesis_stream
-      kinesis_partition_key = var.kinesis_partition_key
-      kinesis_append_new_line = var.kinesis_append_new_line
-      kinesis_data_keys = var.kinesis_data_keys
-      kinesis_role_arn = var.kinesis_role_arn
-      kinesis_endpoint = var.kinesis_endpoint
-      kinesis_sts_endpoint = var.kinesis_sts_endpoint
-      kinesis_time_key = var.kinesis_time_key
-      kinesis_time_key_format = var.kinesis_time_key_format
-      kinesis_compression = var.kinesis_compression
-      kinesis_aggregation = var.kinesis_aggregation
-      kinesis_experimental_concurrency = var.kinesis_experimental_concurrency
+      kinesis_enabled                          = var.kinesis_enabled
+      kinesis_match                            = var.kinesis_match
+      kinesis_stream                           = var.kinesis_stream
+      kinesis_partition_key                    = var.kinesis_partition_key
+      kinesis_append_new_line                  = var.kinesis_append_new_line
+      kinesis_data_keys                        = var.kinesis_data_keys
+      kinesis_role_arn                         = var.kinesis_role_arn
+      kinesis_endpoint                         = var.kinesis_endpoint
+      kinesis_sts_endpoint                     = var.kinesis_sts_endpoint
+      kinesis_time_key                         = var.kinesis_time_key
+      kinesis_time_key_format                  = var.kinesis_time_key_format
+      kinesis_compression                      = var.kinesis_compression
+      kinesis_aggregation                      = var.kinesis_aggregation
+      kinesis_experimental_concurrency         = var.kinesis_experimental_concurrency
       kinesis_experimental_concurrency_retries = var.kinesis_experimental_concurrency_retries
 
-      elastic_search = var.elastic_search_enabled
-      elastic_match = var.elastic_match
-      elastic_host = var.elastic_host
-      elastic_aws_auth = var.elastic_aws_auth
-      elastic_tls = var.elastic_tls
-      elastic_port = var.elastic_port
-      elastic_retry_limit = var.elastic_retry_limit
+      elastic_search                           = var.elastic_search_enabled
+      elastic_match                            = var.elastic_match
+      elastic_host                             = var.elastic_host
+      elastic_aws_auth                         = var.elastic_aws_auth
+      elastic_tls                              = var.elastic_tls
+      elastic_port                             = var.elastic_port
+      elastic_retry_limit                      = var.elastic_retry_limit
     })
   ]
 }

--- a/modules/logging/aws-for-fluent-bit/values/aws-for-fluent-bit.yaml
+++ b/modules/logging/aws-for-fluent-bit/values/aws-for-fluent-bit.yaml
@@ -58,7 +58,7 @@ cloudWatch:
   logStreamPrefix: ${cloudwatch_log_stream_prefix}
   logKey: ${cloudwatch_log_key}
   logFormat: ${cloudwatch_log_format}
-  roleArn: ${cloudwatch_role_arn}
+  roleArn: ${cloudwatch_cross_account_role_arn}
   autoCreateGroup: ${cloudwatch_auto_create_group}
   endpoint: ${cloudwatch_endpoint}
   credentialsEndpoint: ${cloudwatch_credentials_endpoint}
@@ -69,7 +69,7 @@ firehose:
   match: ${firehose_match}
   deliveryStream: ${firehose_delivery_stream}
   dataKeys: ${firehose_data_keys}
-  roleArn: ${firehose_role_arn}
+  roleArn: ${firehose_cross_account_role_arn}
   endpoint: ${firehose_endpoint}
   timeKey: ${firehose_time_key}
   timeKeyFormat: ${firehose_time_key_format}
@@ -82,7 +82,7 @@ kinesis:
   partitionKey: ${kinesis_partition_key}
   appendNewline: ${kinesis_append_new_line}
   dataKeys: ${kinesis_data_keys}
-  roleArn: ${kinesis_role_arn}
+  roleArn: ${kinesis_cross_account_role_arn}
   endpoint: ${kinesis_endpoint}
   stsEndpoint: ${kinesis_sts_endpoint}
   timeKey: ${kinesis_time_key}
@@ -111,7 +111,8 @@ elasticsearch:
 
 serviceAccount:
   create: ${service_account_auto_create}
-  annotations: ${service_account_annotations}
+  annotations:
+    "eks.amazonaws.com/role-arn": ${service_account_role_arn}
   name: ${service_account_name}
 
 resources:

--- a/modules/logging/aws-for-fluent-bit/values/aws-for-fluent-bit.yaml
+++ b/modules/logging/aws-for-fluent-bit/values/aws-for-fluent-bit.yaml
@@ -1,0 +1,135 @@
+global:
+  namespaceOverride: ${namespace}
+
+image:
+  repository: amazon/aws-for-fluent-bit
+  tag: 2.7.0
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  parsersFiles:
+    - /fluent-bit/parsers/parsers.conf
+  # extraParsers: |
+  #   [PARSER]
+  #       Name   logfmt
+  #       Format logfmt
+
+input:
+  tag: "kube.*"
+  path: "/var/log/containers/*.log"
+  db: "/var/log/flb_kube.db"
+  parser: docker
+  dockerMode: "On"
+  memBufLimit: 5MB
+  skipLongLines: "On"
+  refreshInterval: 10
+
+# extraInputs: |
+#   [INPUT]
+#       Name         winlog
+#       Channels     Setup,Windows PowerShell
+#       Interval_Sec 1
+#       DB           winlog.sqlite
+
+filter:
+  match: "kube.*"
+  kubeURL: "https://kubernetes.default.svc.cluster.local:443"
+  mergeLog: "On"
+  mergeLogKey: "data"
+  k8sLoggingParser: "On"
+  k8sLoggingExclude: "On"
+
+# extraFilters: |
+#   [FILTER]
+#       Name   grep
+#       Match  *
+#       Exclude log lvl=debug*
+
+cloudWatch:
+  enabled: ${cloudwatch_enabled}
+  region: ${aws_region}
+  match: ${cloudwatch_match}
+  logGroupName: ${cloudwatch_log_group_name}
+  logStreamName: ${cloudwatch_log_stream_name}
+  logStreamPrefix: ${cloudwatch_log_stream_prefix}
+  logKey: ${cloudwatch_log_key}
+  logFormat: ${cloudwatch_log_format}
+  roleArn: ${cloudwatch_role_arn}
+  autoCreateGroup: ${cloudwatch_auto_create_group}
+  endpoint: ${cloudwatch_endpoint}
+  credentialsEndpoint: ${cloudwatch_credentials_endpoint}
+
+firehose:
+  enabled: ${firehose_enabled}
+  region: ${aws_region}
+  match: ${firehose_match}
+  deliveryStream: ${firehose_delivery_stream}
+  dataKeys: ${firehose_data_keys}
+  roleArn: ${firehose_role_arn}
+  endpoint: ${firehose_endpoint}
+  timeKey: ${firehose_time_key}
+  timeKeyFormat: ${firehose_time_key_format}
+
+kinesis:
+  enabled: ${kinesis_enabled}
+  region: ${aws_region}
+  match: ${kinesis_match}
+  stream: ${kinesis_stream}
+  partitionKey: ${kinesis_partition_key}
+  appendNewline: ${kinesis_append_new_line}
+  dataKeys: ${kinesis_data_keys}
+  roleArn: ${kinesis_role_arn}
+  endpoint: ${kinesis_endpoint}
+  stsEndpoint: ${kinesis_sts_endpoint}
+  timeKey: ${kinesis_time_key}
+  timeKeyFormat: ${kinesis_time_key_format}
+  compression: ${kinesis_compression}
+  aggregation: ${kinesis_aggregation}
+  experimental:
+    concurrency: ${kinesis_experimental_concurrency}
+    concurrencyRetries: ${kinesis_experimental_concurrency_retries}
+
+elasticsearch:
+  enabled: ${elastic_search}
+  awsRegion: ${aws_region}
+  match: ${elastic_match}
+  host: ${elastic_host}
+  awsAuth: ${elastic_aws_auth}
+  tls: ${elastic_tls}
+  port: ${elastic_port}
+  retryLimit: ${elastic_retry_limit}
+
+# extraOutputs: |
+#   [OUTPUT]
+#     Name file
+#     Format template
+#     Template {time} used={Mem.used} free={Mem.free} total={Mem.total}
+
+serviceAccount:
+  create: ${service_account_auto_create}
+  annotations: ${service_account_annotations}
+  name: ${service_account_name}
+
+resources:
+  limits:
+    cpu: ${daemon_set_resources_limits_cpu}
+    memory: ${daemon_set_resources_limits_memory}
+  requests:
+    cpu: ${daemon_set_resources_requests_cpu}
+    memory: ${daemon_set_resources_requests_memory}
+
+## Assign a PriorityClassName to pods if set
+# priorityClassName: system-node-critical
+
+updateStrategy:
+  type: RollingUpdate
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/modules/logging/aws-for-fluent-bit/variables.tf
+++ b/modules/logging/aws-for-fluent-bit/variables.tf
@@ -5,7 +5,7 @@ variable "module_depends_on" {
 
 variable "namespace_name" {
   description = "Name of the namespace where install charts"
-  default = "logging"
+  default     = "logging"
 }
 
 variable "cluster_name" {
@@ -17,162 +17,162 @@ variable "aws_region" {
 }
 
 variable "cloudwatch_enabled" {
-  default = false
+  default     = false
   description = "Whether to enable CloudWatch output"
 }
 
 variable "cloudwatch_match" {
-  default = "'*'"
+  default     = "'*'"
   description = "The log filter"
 }
 
 variable "cloudwatch_log_group_name" {
-  default = "/aws/eks/fluentbit-cloudwatch/logs"
+  default     = "/aws/eks/fluentbit-cloudwatch/logs"
   description = "The name of the CloudWatch Log Group that you want log records sent to"
 }
 
 variable "cloudwatch_log_stream_name" {
-  default = ""
+  default     = ""
   description = "The name of the CloudWatch Log Stream that you want log records sent to."
 }
 
 variable "cloudwatch_log_stream_prefix" {
-  default = "fluentbit-"
+  default     = "fluentbit-"
   description = "Prefix for the Log Stream name"
 }
 
 variable "cloudwatch_log_key" {
-  default = ""
+  default     = ""
   description = "Log record key value of which will be sent to CloudWatch. By default whole message will be sent"
 }
 
 variable "cloudwatch_log_format" {
-  default = ""
+  default     = ""
   description = "Format of the log data"
 }
 
 variable "cloudwatch_role_arn" {
-  default = ""
+  default     = ""
   description = "ARN of an IAM role to assume (cross-account access)"
 }
 
 variable "cloudwatch_auto_create_group" {
-  default = true
+  default     = true
   description = "Whether to automatically create the log group"
 }
 
 variable "cloudwatch_endpoint" {
-  default = ""
+  default     = ""
   description = "Custom endpoint for the CloudWatch Logs API"
 }
 
 variable "cloudwatch_credentials_endpoint" {
-  default = ""
+  default     = ""
   description = "Custom HTTP endpoint to pull credentials from"
 }
 
 variable "firehose_enabled" {
-  default = false
+  default     = false
   description = "Whether to enable Firehose output"
 }
 
 variable "firehose_match" {
-  default = "'*'"
+  default     = "'*'"
   description = "The log filter"
 }
 
 variable "firehose_delivery_stream" {
-  default = ""
+  default     = ""
   description = "The name of the delivery stream that you want log records sent to"
 }
 
 variable "firehose_data_keys" {
-  default = ""
+  default     = ""
   description = "Log record key value of which will be sent to Firehose. By default whole message will be sent"
 }
 
 variable "firehose_role_arn" {
-  default = ""
+  default     = ""
   description = "ARN of an IAM role to assume (cross-account access)"
 }
 
 variable "firehose_endpoint" {
-  default = ""
+  default     = ""
   description = "Custom endpoint for the Kinesis Firehose API"
 }
 
 variable "firehose_time_key" {
-  default = false
+  default     = false
   description = "Whether to add the timestamp to the record under this key"
 }
 
 variable "firehose_time_key_format" {
-  default = ""
+  default     = ""
   description = "Strftime compliant format string for the timestamp"
 }
 
 variable "kinesis_enabled" {
-  default = false
+  default     = false
   description = "Whether to enable Kinesis output"
 }
 
 variable "kinesis_match" {
-  default = "'*'"
+  default     = "'*'"
   description = "The log filter"
 }
 
 variable "kinesis_stream" {
-  default = ""
+  default     = ""
   description = "The name of the Kinesis Data Stream that you want log records sent to"
 }
 
 variable "kinesis_partition_key" {
-  default = "container_name"
+  default     = "container_name"
   description = "A partition key is used to group data by shard within a stream"
 }
 
 variable "kinesis_append_new_line" {
-  default = false
+  default     = false
   description = "Whether to add newline after each log record"
 }
 
 variable "kinesis_data_keys" {
-  default = ""
+  default     = ""
   description = "Log record key value of which will be sent to Firehose. By default whole message will be sent"
 }
 
 variable "kinesis_role_arn" {
-  default = ""
+  default     = ""
   description = "ARN of an IAM role to assume (cross-account access)"
 }
 
 variable "kinesis_endpoint" {
-  default = ""
+  default     = ""
   description = "Custom endpoint for the Kinesis Streams API"
 }
 
 variable "kinesis_sts_endpoint" {
-  default = ""
+  default     = ""
   description = "Custom endpoint for the STS API. Used to assume your custom role provided with kinesis_role_arn variable"
 }
 
 variable "kinesis_time_key" {
-  default = false
+  default     = false
   description = "Whether to add the timestamp to the record"
 }
 
 variable "kinesis_time_key_format" {
-  default = ""
+  default     = ""
   description = "Strftime compliant format string for the timestamp"
 }
 
 variable "kinesis_compression" {
-  default = ""
+  default     = ""
   description = "Setting compression to zlib will enable zlib compression of each record"
 }
 
 variable "kinesis_aggregation" {
-  default = false
+  default     = false
   description = "Setting aggregation to true will enable KPL aggregation of records sent to Kinesis. This feature isn't compatible with the partitionKey feature"
 }
 
@@ -184,37 +184,37 @@ variable "kinesis_experimental_concurrency_retries" {
 }
 
 variable "elastic_search_enabled" {
-  default = false
+  default     = false
   description = "Whether to enable ElasticSearch output"
 }
 
 variable "elastic_match" {
-  default = "'*'"
+  default     = "'*'"
   description = "The logs filter"
 }
 
 variable "elastic_host" {
-  default = ""
+  default     = ""
   description = "The url of the Elastic Search endpoint you want log records sent to"
 }
 
 variable "elastic_aws_auth" {
-  default = "On"
+  default     = "On"
   description = "Whether to enable AWS Sigv4 Authentication for Amazon ElasticSearch Service"
 }
 
 variable "elastic_tls" {
-  default = "On"
+  default     = "On"
   description = "Whether to enable TLS support"
 }
 
 variable "elastic_port" {
-  default = ""
+  default     = ""
   description = "TCP Port of the target service"
 }
 
 variable "elastic_retry_limit" {
-  default = 1
+  default     = 1
   description = "Integer value to set the maximum number of retries allowed"
 }
 
@@ -235,16 +235,16 @@ variable "daemon_set_resources_requests_memory" {
 }
 
 variable "service_account_auto_create" {
-  default = true
+  default     = true
   description = "Whether a new service account should be created"
 }
 
 variable "service_account_name" {
-  default = "aws-for-fluent-bit"
+  default     = "aws-for-fluent-bit"
   description = "Service account name"
 }
 
 variable "service_account_annotations" {
-  default = ""
+  default     = ""
   description = "Service account annotations"
 }

--- a/modules/logging/aws-for-fluent-bit/variables.tf
+++ b/modules/logging/aws-for-fluent-bit/variables.tf
@@ -1,0 +1,250 @@
+# For depends_on queue
+variable "module_depends_on" {
+  default = []
+}
+
+variable "namespace_name" {
+  description = "Name of the namespace where install charts"
+  default = "logging"
+}
+
+variable "cluster_name" {
+  description = "Name of the kubernetes cluster"
+}
+
+variable "aws_region" {
+  description = "Fluent Bit target's AWS Region"
+}
+
+variable "cloudwatch_enabled" {
+  default = false
+  description = "Whether to enable CloudWatch output"
+}
+
+variable "cloudwatch_match" {
+  default = "'*'"
+  description = "The log filter"
+}
+
+variable "cloudwatch_log_group_name" {
+  default = "/aws/eks/fluentbit-cloudwatch/logs"
+  description = "The name of the CloudWatch Log Group that you want log records sent to"
+}
+
+variable "cloudwatch_log_stream_name" {
+  default = ""
+  description = "The name of the CloudWatch Log Stream that you want log records sent to."
+}
+
+variable "cloudwatch_log_stream_prefix" {
+  default = "fluentbit-"
+  description = "Prefix for the Log Stream name"
+}
+
+variable "cloudwatch_log_key" {
+  default = ""
+  description = "Log record key value of which will be sent to CloudWatch. By default whole message will be sent"
+}
+
+variable "cloudwatch_log_format" {
+  default = ""
+  description = "Format of the log data"
+}
+
+variable "cloudwatch_role_arn" {
+  default = ""
+  description = "ARN of an IAM role to assume (cross-account access)"
+}
+
+variable "cloudwatch_auto_create_group" {
+  default = true
+  description = "Whether to automatically create the log group"
+}
+
+variable "cloudwatch_endpoint" {
+  default = ""
+  description = "Custom endpoint for the CloudWatch Logs API"
+}
+
+variable "cloudwatch_credentials_endpoint" {
+  default = ""
+  description = "Custom HTTP endpoint to pull credentials from"
+}
+
+variable "firehose_enabled" {
+  default = false
+  description = "Whether to enable Firehose output"
+}
+
+variable "firehose_match" {
+  default = "'*'"
+  description = "The log filter"
+}
+
+variable "firehose_delivery_stream" {
+  default = ""
+  description = "The name of the delivery stream that you want log records sent to"
+}
+
+variable "firehose_data_keys" {
+  default = ""
+  description = "Log record key value of which will be sent to Firehose. By default whole message will be sent"
+}
+
+variable "firehose_role_arn" {
+  default = ""
+  description = "ARN of an IAM role to assume (cross-account access)"
+}
+
+variable "firehose_endpoint" {
+  default = ""
+  description = "Custom endpoint for the Kinesis Firehose API"
+}
+
+variable "firehose_time_key" {
+  default = false
+  description = "Whether to add the timestamp to the record under this key"
+}
+
+variable "firehose_time_key_format" {
+  default = ""
+  description = "Strftime compliant format string for the timestamp"
+}
+
+variable "kinesis_enabled" {
+  default = false
+  description = "Whether to enable Kinesis output"
+}
+
+variable "kinesis_match" {
+  default = "'*'"
+  description = "The log filter"
+}
+
+variable "kinesis_stream" {
+  default = ""
+  description = "The name of the Kinesis Data Stream that you want log records sent to"
+}
+
+variable "kinesis_partition_key" {
+  default = "container_name"
+  description = "A partition key is used to group data by shard within a stream"
+}
+
+variable "kinesis_append_new_line" {
+  default = false
+  description = "Whether to add newline after each log record"
+}
+
+variable "kinesis_data_keys" {
+  default = ""
+  description = "Log record key value of which will be sent to Firehose. By default whole message will be sent"
+}
+
+variable "kinesis_role_arn" {
+  default = ""
+  description = "ARN of an IAM role to assume (cross-account access)"
+}
+
+variable "kinesis_endpoint" {
+  default = ""
+  description = "Custom endpoint for the Kinesis Streams API"
+}
+
+variable "kinesis_sts_endpoint" {
+  default = ""
+  description = "Custom endpoint for the STS API. Used to assume your custom role provided with kinesis_role_arn variable"
+}
+
+variable "kinesis_time_key" {
+  default = false
+  description = "Whether to add the timestamp to the record"
+}
+
+variable "kinesis_time_key_format" {
+  default = ""
+  description = "Strftime compliant format string for the timestamp"
+}
+
+variable "kinesis_compression" {
+  default = ""
+  description = "Setting compression to zlib will enable zlib compression of each record"
+}
+
+variable "kinesis_aggregation" {
+  default = false
+  description = "Setting aggregation to true will enable KPL aggregation of records sent to Kinesis. This feature isn't compatible with the partitionKey feature"
+}
+
+variable "kinesis_experimental_concurrency" {
+  default = ""
+}
+variable "kinesis_experimental_concurrency_retries" {
+  default = ""
+}
+
+variable "elastic_search_enabled" {
+  default = false
+  description = "Whether to enable ElasticSearch output"
+}
+
+variable "elastic_match" {
+  default = "'*'"
+  description = "The logs filter"
+}
+
+variable "elastic_host" {
+  default = ""
+  description = "The url of the Elastic Search endpoint you want log records sent to"
+}
+
+variable "elastic_aws_auth" {
+  default = "On"
+  description = "Whether to enable AWS Sigv4 Authentication for Amazon ElasticSearch Service"
+}
+
+variable "elastic_tls" {
+  default = "On"
+  description = "Whether to enable TLS support"
+}
+
+variable "elastic_port" {
+  default = ""
+  description = "TCP Port of the target service"
+}
+
+variable "elastic_retry_limit" {
+  default = 1
+  description = "Integer value to set the maximum number of retries allowed"
+}
+
+variable "daemon_set_resources_limits_cpu" {
+  default = "500m"
+}
+
+variable "daemon_set_resources_limits_memory" {
+  default = "500Mi"
+}
+
+variable "daemon_set_resources_requests_cpu" {
+  default = "500m"
+}
+
+variable "daemon_set_resources_requests_memory" {
+  default = "500Mi"
+}
+
+variable "service_account_auto_create" {
+  default = true
+  description = "Whether a new service account should be created"
+}
+
+variable "service_account_name" {
+  default = "aws-for-fluent-bit"
+  description = "Service account name"
+}
+
+variable "service_account_annotations" {
+  default = ""
+  description = "Service account annotations"
+}

--- a/modules/logging/aws-for-fluent-bit/variables.tf
+++ b/modules/logging/aws-for-fluent-bit/variables.tf
@@ -3,6 +3,15 @@ variable "module_depends_on" {
   default = []
 }
 
+variable "environment" {}
+
+variable "project" {}
+
+variable "create_namespace" {
+  description = "Whether to create new kubernetes namespace"
+  default     = true
+}
+
 variable "namespace_name" {
   description = "Name of the namespace where install charts"
   default     = "logging"
@@ -12,8 +21,21 @@ variable "cluster_name" {
   description = "Name of the kubernetes cluster"
 }
 
+variable "cluster_oidc_arn" {
+  description = "OIDC EKS cluster ARN"
+}
+
+variable "cluster_oidc_url" {
+  description = "OIDC EKS cluster endpoint"
+}
+
 variable "aws_region" {
   description = "Fluent Bit target's AWS Region"
+}
+
+variable "aws_account" {
+  description = "AWS Account ID for IAM policy"
+  default     = "*"
 }
 
 variable "cloudwatch_enabled" {
@@ -51,7 +73,7 @@ variable "cloudwatch_log_format" {
   description = "Format of the log data"
 }
 
-variable "cloudwatch_role_arn" {
+variable "cloudwatch_cross_account_role_arn" {
   default     = ""
   description = "ARN of an IAM role to assume (cross-account access)"
 }
@@ -91,7 +113,7 @@ variable "firehose_data_keys" {
   description = "Log record key value of which will be sent to Firehose. By default whole message will be sent"
 }
 
-variable "firehose_role_arn" {
+variable "firehose_cross_account_role_arn" {
   default     = ""
   description = "ARN of an IAM role to assume (cross-account access)"
 }
@@ -141,7 +163,7 @@ variable "kinesis_data_keys" {
   description = "Log record key value of which will be sent to Firehose. By default whole message will be sent"
 }
 
-variable "kinesis_role_arn" {
+variable "kinesis_cross_account_role_arn" {
   default     = ""
   description = "ARN of an IAM role to assume (cross-account access)"
 }
@@ -242,9 +264,4 @@ variable "service_account_auto_create" {
 variable "service_account_name" {
   default     = "aws-for-fluent-bit"
   description = "Service account name"
-}
-
-variable "service_account_annotations" {
-  default     = ""
-  description = "Service account annotations"
 }


### PR DESCRIPTION
Fixes #104.

Adds module for deploying AWS For Fluent Bit.

Possible output plugins are:
* CloudWatch
* Kinesis Data Stream
* Kinesis Firehose
* ElasticSearch cluster