### PR TITLE
add external-secrets module and enable irsa in kubernetes

### DIFF
--- a/examples/argocd-with-applications/main.tf
+++ b/examples/argocd-with-applications/main.tf
@@ -84,3 +84,10 @@ module external_dns {
   hostedzones  = local.domain
   tags         = local.tags
 }
+
+module "external-secrets" {
+  source         = "../../modules/system/external-secrets"
+  cluster_output = module.kubernetes.this
+  argocd         = module.argocd.state
+  tags           = local.tags
+}

--- a/examples/argocd-with-applications/main.tf
+++ b/examples/argocd-with-applications/main.tf
@@ -85,7 +85,7 @@ module external_dns {
   tags         = local.tags
 }
 
-module "external-secrets" {
+module "external_secrets" {
   source         = "../../modules/system/external-secrets"
   cluster_output = module.kubernetes.this
   argocd         = module.argocd.state

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -17,6 +17,7 @@ module "eks" {
   kubeconfig_name = var.cluster_name
   subnets         = var.subnets
   vpc_id          = var.vpc_id
+  enable_irsa     = true
 
   map_users = concat(var.admin_arns, var.user_arns)
 

--- a/modules/system/external-secrets/README.md
+++ b/modules/system/external-secrets/README.md
@@ -1,0 +1,39 @@
+# External Secrets
+__warning:__ this module only works with ArgoCD
+
+## Example
+``` hcl
+module external_secrets {
+  source         = "git::https://github.com/provectus/swiss-army-kube.git//modules/system/external-secrets"
+  argocd         = module.argocd.state
+  cluster_output = module.kubernetes
+}
+```
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| local | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| allowed\_secrets\_prefix | Prefix of for secrets we should be able to access from the external-secrets app? | `string` | `"/eks/"` | no |
+| argocd | A set of values for enabling deployment through ArgoCD | `map(string)` | `{}` | no |
+| aws\_assume\_role\_arn | A role to assume | `string` | `""` | no |
+| aws\_region | A name of the AWS region (us-central-1, us-west-2 and etc.) | `string` | `""` | no |
+| chart\_parameters | A list of parameters that will override defaults | `list` | `[]` | no |
+| chart\_parameters\_as\_string | A list of parameters that will override defaults | `list` | `[]` | no |
+| chart\_repository | n/a | `string` | `"https://external-secrets.github.io/kubernetes-external-secrets/"` | no |
+| chart\_values | Chart values | `string` | `""` | no |
+| chart\_version | A Helm Chart version | `string` | `"6.0.0"` | no |
+| cluster\_output | Cluster output object from Kubernetes module | `any` | n/a | yes |
+| poller\_interval | Interval of refreshing values from secrets manager in ms | `string` | `"30000"` | no |
+| tags | A tags for attaching to new created AWS resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+No output.

--- a/modules/system/external-secrets/helm-app-template/external-secrets.yaml
+++ b/modules/system/external-secrets/helm-app-template/external-secrets.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ${app_name}
+  namespace: ${argo_namespace}
+spec:
+  destination:
+    namespace: ${app_name}
+    server: 'https://kubernetes.default.svc'
+  source:
+    repoURL: ${chart_repo}
+    targetRevision: ${chart_version}
+    chart: kubernetes-${app_name}
+%{ if chart_parameters_as_string != [] || chart_parameters != []  || chart_values != "" }
+    helm:
+%{ if chart_parameters_as_string != [] || chart_parameters != [] }
+      parameters:
+%{ if chart_parameters_as_string != [] }
+%{ for key in chart_parameters_as_string ~}
+        - name: '${key.name}'
+          value: '${key.value}'
+          forceString: true
+%{ endfor ~}
+%{ endif }
+%{ if chart_parameters != [] }
+%{ for key in chart_parameters ~}
+        - name: '${key.name}'
+          value: '${key.value}'
+%{ endfor ~}
+%{ endif }
+%{ endif }
+%{ if chart_values != "" }
+      values: |
+        ${indent(8, chart_values)}
+%{ endif }
+%{ endif }
+  project: default
+  syncPolicy:
+    automated: {}

--- a/modules/system/external-secrets/iam.tf
+++ b/modules/system/external-secrets/iam.tf
@@ -1,0 +1,56 @@
+resource "aws_iam_role" "external_secrets" {
+  count = var.chart_values != "" || var.aws_assume_role_arn != "" ? 0 : 1
+  name  = "external-secrets-${local.cluster_name}"
+  tags  = var.tags
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${var.cluster_output.oidc_provider_arn}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringLike": {
+           "${replace(var.cluster_output.cluster_oidc_issuer_url, "https://", "")}:sub": "system:serviceaccount:${local.app_name}:*"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "external_secrets_access" {
+  count = var.chart_values != "" || var.aws_assume_role_arn != "" ? 0 : 1
+  name  = "external-secrets-${local.cluster_name}-access"
+  role  = aws_iam_role.external_secrets[count.index].id
+
+  policy = <<-EOF
+{
+  "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "SecretsAccess",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:ListSecretVersionIds",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:GetResourcePolicy",
+                "secretsmanager:DescribeSecret"
+            ],
+            "Resource": "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.allowed_secrets_prefix}*"
+        },
+        {
+            "Sid": "RoleAssume",
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "${aws_iam_role.external_secrets[count.index].arn}"
+        }
+    ]
+}
+  EOF
+}

--- a/modules/system/external-secrets/locals.tf
+++ b/modules/system/external-secrets/locals.tf
@@ -1,0 +1,15 @@
+locals {
+  module_name         = basename(abspath(path.module))
+  app_name            = "external-secrets"
+  cluster_name        = var.cluster_output.cluster_id
+  aws_region          = var.aws_region == "" ? data.aws_region.current.name : var.aws_region
+  aws_assume_role_arn = length(aws_iam_role.external_secrets) > 0 && var.aws_assume_role_arn == "" ? aws_iam_role.external_secrets[0].arn : var.aws_assume_role_arn
+  template_helm_values = templatefile("${path.module}/values/values.yaml",
+    {
+      aws_assume_role_arn = local.aws_assume_role_arn
+      poller_interval     = var.poller_interval
+      aws_region          = local.aws_region
+      app_name            = local.app_name
+  })
+  chart_values = var.chart_values == "" ? local.template_helm_values : var.chart_values
+}

--- a/modules/system/external-secrets/main.tf
+++ b/modules/system/external-secrets/main.tf
@@ -1,0 +1,21 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+
+resource "local_file" "values" {
+  content = templatefile("${path.module}/helm-app-template/${local.app_name}.yaml",
+    {
+      chart_values               = local.chart_values
+      chart_repo                 = var.chart_repository
+      chart_version              = var.chart_version
+      module_name                = local.module_name
+      app_name                   = local.app_name
+      chart_parameters           = var.chart_parameters
+      chart_parameters_as_string = var.chart_parameters_as_string
+      argo_namespace             = var.argocd.namespace
+  })
+  file_permission      = "0644"
+  directory_permission = "0755"
+  filename             = "${path.root}/${var.argocd.path}/${local.app_name}.yaml"
+}

--- a/modules/system/external-secrets/rendered_example/external-secrets.yaml
+++ b/modules/system/external-secrets/rendered_example/external-secrets.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argo-cd
+spec:
+  destination:
+    namespace: external-secrets
+    server: 'https://kubernetes.default.svc'
+  source:
+    repoURL: https://external-secrets.github.io/kubernetes-external-secrets/
+    targetRevision: 6.0.0
+    chart: kubernetes-external-secrets
+    helm:
+      parameters:
+        - name: 'env.POLLER_INTERVAL_MILLISECONDS'
+          value: '50000'
+          forceString: true
+      values: |
+        securityContext:
+          runAsNonRoot: true
+          fsGroup: 1000
+        env:
+          AWS_REGION: us-east-1
+          AWS_DEFAULT_REGION: us-east-1
+          POLLER_INTERVAL_MILLISECONDS: 30000
+        serviceAccount:
+          annotations: 
+            eks.amazonaws.com/role-arn: arn:aws:iam::SOME_ACCOUNT_NUMBER:role/external-secrets-your-cluster
+  project: default
+  syncPolicy:
+    automated: {}

--- a/modules/system/external-secrets/values/values.yaml
+++ b/modules/system/external-secrets/values/values.yaml
@@ -1,0 +1,12 @@
+securityContext:
+  runAsNonRoot: true
+  fsGroup: 1000
+
+env:
+  AWS_REGION: ${aws_region}
+  AWS_DEFAULT_REGION: ${aws_region}
+  POLLER_INTERVAL_MILLISECONDS: ${poller_interval}
+
+serviceAccount:
+  annotations: 
+    eks.amazonaws.com/role-arn: ${aws_assume_role_arn}

--- a/modules/system/external-secrets/variables.tf
+++ b/modules/system/external-secrets/variables.tf
@@ -1,0 +1,62 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS Region with Secrets manager to access default - current"
+  default     = ""
+}
+
+variable "chart_version" {
+  type        = string
+  description = "Version of the helm chart for External Secrets"
+  default     = "6.0.0"
+}
+
+variable "poller_interval" {
+  type        = string
+  description = "Interval of refreshing values from secrets manager in ms"
+  default     = "30000"
+}
+
+variable "cluster_output" {
+  description = "cluster output object from Kubernetes module"
+
+}
+
+variable "chart_repository" {
+  type    = string
+  default = "https://external-secrets.github.io/kubernetes-external-secrets/"
+}
+
+variable "chart_values" {
+  default     = ""
+  description = "Chart values"
+}
+
+variable "aws_assume_role_arn" {
+  default     = ""
+  description = "A role to assume"
+}
+
+variable "chart_parameters" {
+  default     = []
+  description = "A list of parameters that will override defaults"
+}
+
+variable "chart_parameters_as_string" {
+  default     = []
+  description = "A list of parameters that will override defaults"
+}
+
+variable "tags" {
+  default = {}
+}
+
+variable "allowed_secrets_prefix" {
+  type        = string
+  description = "Prefix of for secrets we should be able to access from the external-secrets app?"
+  default     = "/eks/"
+}
+variable "argocd" {
+  type        = map(string)
+  description = "A set of values for enabling deployment through ArgoCD"
+  default     = {}
+}

--- a/modules/system/external-secrets/variables.tf
+++ b/modules/system/external-secrets/variables.tf
@@ -1,12 +1,12 @@
 variable "aws_region" {
   type        = string
-  description = "AWS Region with Secrets manager to access default - current"
+  description = "A name of the AWS region (us-central-1, us-west-2 and etc.)"
   default     = ""
 }
 
 variable "chart_version" {
   type        = string
-  description = "Version of the helm chart for External Secrets"
+  description = "A Helm Chart version"
   default     = "6.0.0"
 }
 
@@ -17,8 +17,7 @@ variable "poller_interval" {
 }
 
 variable "cluster_output" {
-  description = "cluster output object from Kubernetes module"
-
+  description = "Cluster output object from Kubernetes module"
 }
 
 variable "chart_repository" {
@@ -47,7 +46,9 @@ variable "chart_parameters_as_string" {
 }
 
 variable "tags" {
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A tags for attaching to new created AWS resources"
 }
 
 variable "allowed_secrets_prefix" {


### PR DESCRIPTION
In this PR I suggest to consider another approach to helm chart deployments with ArgoCD
Notice how there are two ways to provide values - whole values file and additional parameters, which will override values.