### PR TITLE
Fix for creation of GPU nodes

### DIFF
--- a/modules/kubernetes/local.tf
+++ b/modules/kubernetes/local.tf
@@ -78,7 +78,8 @@ locals {
   gpu = values({
     "gpu" = {
       name_prefix                              = "on-demand-gpu-"
-      override_instance_types                  = var.on_demand_gpu_instance_type
+      instance_type                            = var.on_demand_gpu_instance_type
+      override_instance_types                  = var.on_demand_gpu_override_instance_types
       asg_max_size                             = var.on_demand_gpu_max_cluster_size
       asg_min_size                             = var.on_demand_gpu_min_cluster_size
       asg_desired_capacity                     = var.on_demand_gpu_desired_capacity
@@ -125,7 +126,7 @@ locals {
         {
           "key"                 = "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu"
           "propagate_at_launch" = "false"
-          "value"               = "1" # Change to the number of GPUs on your node type
+          "value"               = var.on_demand_gpu_resource_count
         }
       ]
     }

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -47,10 +47,3 @@ module "eks" {
   #
   worker_groups_launch_template = concat(local.common, local.cpu, local.gpu)
 }
-
-# OIDC cluster EKS settings
-resource "aws_iam_openid_connect_provider" "cluster" {
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
-  url             = module.eks.cluster_oidc_issuer_url
-}

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -171,7 +171,17 @@ variable "on_demand_gpu_desired_capacity" {
 
 variable "on_demand_gpu_instance_type" {
   description = "EC2 on_demand Instance type"
+  default     = "p2.xlarge"
+}
+
+variable "on_demand_gpu_override_instance_types" {
+  description = "EC2 on_demand Instance types for overriding"
   default     = ["p2.xlarge", "g4dn.xlarge", "p3.2xlarge"]
+}
+
+variable "on_demand_gpu_resource_count" {
+  description = "A number of GPUs resopurces for the instance type"
+  default     = 1
 }
 
 variable "on_demand_gpu_allocation_strategy" {
@@ -182,7 +192,6 @@ variable "on_demand_gpu_allocation_strategy" {
 variable "on_demand_gpu_base_capacity" {
   description = "Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances"
   default     = "0"
-
 }
 
 variable "on_demand_gpu_percentage_above_base_capacity" {


### PR DESCRIPTION
Added ability to specify the number of GPUs, by default GPU instances were launched on m4.large instance type, now changed to p2 family instances