### PR TITLE
WIP: add optional registry mirrors to docker.hub to avoid pull limits

### DIFF
--- a/modules/kubernetes/local.tf
+++ b/modules/kubernetes/local.tf
@@ -133,4 +133,34 @@ locals {
       ]
     }
   })
+
+  ssm_agent_userdata = <<-EOT
+    yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+    systemctl enable amazon-ssm-agent
+    systemctl start amazon-ssm-agent
+  EOT
+
+  registry_mirrors_userdata = (length(var.node_registry_mirrors) > 0 ?
+    <<-EOT
+      containerd config dump | \
+      sed -r -e \
+      '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\.mirrors\."docker\.io"\]/{n;s|(endpoint\s*=\s*)\[(.*)|\1[%{for registry_mirror in var.node_registry_mirrors~}"${registry_mirror}",%{endfor~}\2|}' \
+      > /etc/containerd/config.toml
+      systemctl restart containerd
+
+      if [ -f /etc/docker/daemon.json ]; then
+          REGISTRY_MIRRORS="%{for registry_mirror in var.node_registry_mirrors~}'${registry_mirror}',%{endfor~}"
+          cat /etc/docker/daemon.json | \
+          python -c \
+          "import json,sys; conf=json.load(sys.stdin); conf['registry-mirrors']=[$${REGISTRY_MIRRORS%%,}]; print(json.dumps(conf, indent=2))" > \
+          /tmp/daemon-changed.json
+          yes | cp -f /tmp/daemon-changed.json /etc/docker/daemon.json
+          rm -f /tmp/daemon-changed.json
+
+          systemctl restart docker.service
+      fi
+    EOT
+  : "")
+
+  additional_userdata = join("\n", [local.ssm_agent_userdata, local.registry_mirrors_userdata])
 }

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -36,7 +36,7 @@ module "eks" {
   ]
 
   workers_group_defaults = {
-    additional_userdata = "sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm && sudo systemctl enable amazon-ssm-agent && sudo systemctl start amazon-ssm-agent"
+    additional_userdata = local.additional_userdata
   }
 
   # Note:

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -60,6 +60,12 @@ variable "user_arns" {
   default = []
 }
 
+variable "node_registry_mirrors" {
+  type        = list
+  default     = []
+  description = "EC2 node docker registry mirrors (only for EKS-optimized AMIs)"
+}
+
 # On-demand instance
 variable "on_demand_common_max_cluster_size" {
   type        = string


### PR DESCRIPTION
#### Changes

This PR changes `userdata` for EC2 nodes in k8s cluster - if `node_registry_mirrors` variable isn't empty it changes configs for the following services:

* containerd - changes registry mirror settings. This will take effect when kubernetes completely deprecates docker as runtime - it will use CRI compliant runtime (containerd) - see https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/

* dockerd - changes registry mirror settings 


#### To-do

* how to test/debug/validate
* documentation (ping @Evanto)