### PR TITLE
issue: #201 mac arm

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,7 +6,7 @@ on:
     - '**.tfvars'
     - '**.tfvars.json'
 env:
-  TERRAFORM_VERSION: "0.14.4"
+  TERRAFORM_VERSION: "0.15.4"
 
 jobs:
   tflint:

--- a/examples/argocd-with-applications/versions.tf
+++ b/examples/argocd-with-applications/versions.tf
@@ -28,10 +28,6 @@ terraform {
       source  = "hashicorp/random"
       version = "3.1.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
-    }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
 }

--- a/examples/argocd/versions.tf
+++ b/examples/argocd/versions.tf
@@ -28,10 +28,6 @@ terraform {
       source  = "hashicorp/random"
       version = "3.1.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
-    }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
 }

--- a/examples/common/versions.tf
+++ b/examples/common/versions.tf
@@ -28,10 +28,6 @@ terraform {
       source  = "hashicorp/random"
       version = "3.1.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
-    }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
 }

--- a/examples/docker-reverse-proxy/versions.tf
+++ b/examples/docker-reverse-proxy/versions.tf
@@ -28,10 +28,6 @@ terraform {
       source  = "hashicorp/random"
       version = "3.1.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
-    }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
 }

--- a/examples/hydrosphere/versions.tf
+++ b/examples/hydrosphere/versions.tf
@@ -28,10 +28,6 @@ terraform {
       source  = "hashicorp/random"
       version = "3.1.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
-    }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
 }


### PR DESCRIPTION
1. Bumped minimal terraform version to 0.15 in examples (which is compatible with newest version).
2. Removed usage of "template" module from examples.

template module is outdated and not available for arm arch.