### PR TITLE
#242: upgrade vpc module version to fix issue with aws provider

### DIFF
--- a/examples/argocd/main.tf
+++ b/examples/argocd/main.tf
@@ -10,7 +10,7 @@ data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "v2.64.0"
+  version = "v5.1.0"
 
   name = "${local.environment}-${local.cluster_name}"
 


### PR DESCRIPTION
The problem related to recent terraform aws-provider upgrade. The provider has deprecated some of the terraform resources which are used in vpc module. Updating of vpc-module fixes that issue.

The changes are tested, everything works as expected.